### PR TITLE
Edit Docs to include the new method for Widget JS Handlers

### DIFF
--- a/src/controls/frontend-available.md
+++ b/src/controls/frontend-available.md
@@ -190,10 +190,9 @@ class TestWidgetHandler extends elementorModules.frontend.handlers.Base {
  * JS handler.
  */
 window.addEventListener( 'elementor/frontend/init', () => {
-	const addHandler = ( $element ) => {
-		elementorFrontend.elementsHandler.addHandler( TestWidgetHandler, { $element } );
-	};
-
-	elementorFrontend.hooks.addAction( 'frontend/element_ready/test_widget.default', addHandler );
+    elementorFrontend.elementsHandler.attachHandler(
+      "test_widget",
+      TestWidgetHandler
+    );
 } );
 ```


### PR DESCRIPTION
Inline with https://developers.elementor.com/a-new-method-for-attaching-a-js-handler-to-an-element/

I have updated the example to use the new attachHandler() function