### PR TITLE
Fixed: return value of get_group

### DIFF
--- a/src/dynamic-tags/dynamic-tags-groups.md
+++ b/src/dynamic-tags/dynamic-tags-groups.md
@@ -28,7 +28,7 @@ When creating new dynamic tags, you can set the tag group by returning group nam
 class Elementor_Test_Tag extends \Elementor\Core\DynamicTags\Tag {
 
 	public function get_group() {
-		return [ 'actions' ];
+		return [ 'action' ];
 	}
 
 }


### PR DESCRIPTION
Class Elementor_Test_Tag::get_group should return ['action'] not ['actions']