### PR TITLE
Update unregistering-widgets.md

### DIFF
--- a/src/managers/unregistering-widgets.md
+++ b/src/managers/unregistering-widgets.md
@@ -50,7 +50,7 @@ function remove_unused_widgets( $widgets_manager ) {
 		// 'divider',
 		// 'spacer',
 		// 'image-box',
-		// 'google-maps',
+		// 'google_maps',
 		// 'icon',
 		// 'icon-box',
 		// 'star-rating',
@@ -73,7 +73,7 @@ function remove_unused_widgets( $widgets_manager ) {
 		// 'read-more',
 	];
 
-	foreach ( $widgets_list as $widget ) {
+	foreach ( $widgets_to_unregister as $widget ) {
 		$widgets_manager->unregister( $widget );
 	}
 


### PR DESCRIPTION
The Google Maps widgets have the wrong name, the correct one would be google_maps, because that's what's in the widget file but it found a pattern break since all the others follow the kebab-case pattern.

And the variable name in the loop was wrong too