### PR TITLE
Update responsive-control.md

### DIFF
--- a/src/editor-controls/responsive-control.md
+++ b/src/editor-controls/responsive-control.md
@@ -56,7 +56,7 @@ class Elementor_Test_Widget extends \Elementor\Widget_Base {
 					],
 				],
 				'devices' => [ 'desktop', 'tablet', 'mobile' ],
-				'desktop_default' => [
+				'default' => [
 					'size' => 30,
 					'unit' => 'px',
 				],


### PR DESCRIPTION
### Description:
The `desktop_default` was giving an empty input field in the editor without any default desktop value. The `tablet_default`and `mobile_default` were functioning properly, and with having respective default values as well.

Updating `desktop_default` to just `default` resolved the issue.

### Test Example:

```
$this->add_responsive_control(
    'test_input',
    [
        'type' => \Elementor\Controls_Manager::SLIDER,
        'label' => esc_html__('Test Input', 'textdomain'),
        'size_units' => ['px', '%', 'em', 'rem', 'vw'],
        'range' => [
            'px' => [
                'min' => -25,
                'max' => 200,
                'step' => 25,
            ],
        ],
        'devices' => [ 'desktop', 'tablet', 'mobile' ],
        'desktop_default' => [
            'size' => 30,
            'unit' => 'px',
        ],
        'tablet_default' => [
            'size' => 20,
            'unit' => 'px',
        ],
        'mobile_default' => [
            'size' => 10,
            'unit' => 'px',
        ],
    ]
);
```