### PR TITLE
Update group-control-background.md

### DIFF
--- a/src/editor-controls/group-control-background.md
+++ b/src/editor-controls/group-control-background.md
@@ -114,4 +114,4 @@ class Elementor_Test_Widget extends \Elementor\Widget_Base {
 
 ## Notes
 
-Video background is only supported at section level, not on widget level.
+Video and slideshow types are supported only at section/container level, not widget level.


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update documentation to clarify that both video and slideshow background types are restricted to section/container level.

Main changes:
- Changed note from "Video background is only supported..." to include slideshow type
- Clarified that restriction applies to both video and slideshow background types

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
