### PR TITLE
Fixed JS hooks documentation does not educate about integrating with widgets.

### DIFF
--- a/src/hooks/js.md
+++ b/src/hooks/js.md
@@ -136,6 +136,28 @@ elementorFrontend.hooks.addAction( 'frontend/element_ready/google-maps.satellite
 } );
 ```
 
+## Integrating with widgets
+
+Elementor Frontend does not trigger an event when a widget is initialized and loaded.  And most widgets use hardcoded parameters derived from element settings, so you cannot customize them from PHP or JavaScript.
+
+You can use the regular window.onLoad event to act on elements when page loading has completed.
+
+#### Example
+
+```js
+jQuery(document).ready(function ($) {
+	// Swiper instance only exists after image carousel widget
+	// has been initialized.
+	$(window).on('load', () => {
+		const $carousel = $('.swiper');
+		if ($carousel.data('swiper')) {
+			const swiper = $carousel.data('swiper');
+			swiper.params.a11y.containerRole = 'button';
+		}
+	});
+});
+```
+
 ## Editor Hooks
 
 ### `panel/open_editor/{elementType}`


### PR DESCRIPTION
Problem
- As a site builder, it is not possible to customize the behavior if the e.g. image carousel widget's Swiper slider.

Proposed solution
1. As we cannot easily invent a pattern to allow standardized manipulation of how widgets are instrumenting third-party libraries, we at least can clarify the docs on how developers can gain access to such libraries after widgets have been initialized.

Notes
- I researched for several hours, tried various suggested solutions that all did not work. I imagine many other developers are facing the same struggle.
- Yes, widgets provide an init hook, but it is invoked too early.
- Swiper's afterInit event callback can only be specified in the initial parameters passed to the instance, not afterwards.
- The proposed solution is taken from https://github.com/elementor/elementor/issues/11067#issuecomment-1199667009